### PR TITLE
Make benchmarks compilable

### DIFF
--- a/fast-builder.cabal
+++ b/fast-builder.cabal
@@ -10,10 +10,10 @@ license:             PublicDomain
 license-file:        LICENSE
 author:              Takano Akio
 maintainer:          aljee@hyper.cx
--- copyright:           
+-- copyright:
 category:            Data
 build-type:          Simple
--- extra-source-files:  
+extra-source-files:  benchmarks/aeson/*.hs
 cabal-version:       >=1.10
 tested-with:         GHC >= 7.10.1 && < 8
 
@@ -22,9 +22,9 @@ library
                        Data.ByteString.FastBuilder.Internal
   other-modules:       Data.ByteString.FastBuilder.Internal.Prim
 
-  -- other-extensions:    
+  -- other-extensions:
   build-depends:       base >= 4.8 && < 4.9, bytestring >= 0.10.6.0, ghc-prim
-  -- hs-source-dirs:      
+  -- hs-source-dirs:
   default-language:    Haskell2010
   ghc-options:         -Wall -g
 
@@ -33,6 +33,7 @@ benchmark aeson
   main-is:             main.hs
   hs-source-dirs:      benchmarks/aeson
   other-modules:       Fast, Bstr, HashMapExts
+  include-dirs:        benchmarks/aeson
   build-depends:       base, fast-builder, aeson, criterion, bytestring,
     scientific, text, vector, deepseq, unordered-containers, ghc-prim,
     template-haskell, true-name >= 0.1.0.0


### PR DESCRIPTION
`benchmarks/aeson/template.hs` isn't distributed with `cabal sdist` since it isn't listed in the `extra-source-files` field of the `.cabal` field, so the benchmarks for `fast-builder` fail to compile when obtained from Hackage.

See also https://github.com/fpco/stackage/issues/1372#issuecomment-213020065
