### PR TITLE
Add hPutBuilderCapacity method.

### DIFF
--- a/Data/ByteString/FastBuilder/Internal.hs
+++ b/Data/ByteString/FastBuilder/Internal.hs
@@ -39,6 +39,7 @@ module Data.ByteString.FastBuilder.Internal
   , toLazyByteStringWith
   , toStrictByteString
   , hPutBuilder
+  , hPutBuilderCapacity
 
   -- * Basic builders
   , primBounded
@@ -467,8 +468,14 @@ toStrictByteString builder = unsafePerformIO $ do
 
 -- | Output a 'Builder' to a 'IO.Handle'.
 hPutBuilder :: IO.Handle -> Builder -> IO ()
-hPutBuilder !h builder = do
-  let cap = 100
+hPutBuilder !h builder = hPutBuilderCapacity h 100 builder
+
+-- | Output a 'Builder' to a 'IO.Handle'.
+-- Allows to set initial capacity. This method may be useful for
+-- setting large buffer when high throughput I/O is needed.
+hPutBuilderCapacity :: IO.Handle -> Int -> Builder -> IO ()
+hPutBuilderCapacity !h capacity builder = do
+  let cap = capacity
   fptr <- mallocForeignPtrBytes cap
   qRef <- newIORef $ Queue fptr 0
   let !base = unsafeForeignPtrToPtr fptr


### PR DESCRIPTION
Default capacity of the hPutBuilder is very low, and if
all dumped data is small then builder would never increase
4096 bytes, that is too low for a high throughput I/O.
If value is tweaked manually then it's possible to have a
10 times improvement in running time.