### PR TITLE
Add unsafeCStringLen builder.

### DIFF
--- a/Data/ByteString/FastBuilder/Internal.hs
+++ b/Data/ByteString/FastBuilder/Internal.hs
@@ -51,6 +51,7 @@ module Data.ByteString.FastBuilder.Internal
   , byteStringCopyNoCheck
   , byteStringInsert
   , unsafeCString
+  , unsafeCStringLen
   , ensureBytes
   , getBytes
 
@@ -609,6 +610,13 @@ unsafeCString cstr = rebuild $ let
   setCur $ cur `plusPtr` len
 
 foreign import ccall unsafe "strlen" c_pure_strlen :: CString -> CSize
+
+-- | Turn a 'CStringLen' into a 'Builder'.
+unsafeCStringLen :: CStringLen -> Builder
+unsafeCStringLen (ptr, len) = mappend (ensureBytes len) $ mkBuilder $ do
+  cur <- getCur
+  io $ copyBytes cur (castPtr ptr) len
+  setCur $ cur `plusPtr` len
 
 -- | @'ensureBytes' n@ ensures that at least @n@ bytes of free space is
 -- available in the current buffer, by allocating a new buffer when


### PR DESCRIPTION
unsafeCStringLen builder provides an efficient
way to append CStringLen to a builder.
`rebuild` was not explicitly added, as in local experiments
in provided a negative impact on the running time, so it
left to the user if she wants to rebuild builder.