### PR TITLE
Update to ghc 9.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.stack-work/
 /dist/
+/dist-newstyle/

--- a/fast-builder.cabal
+++ b/fast-builder.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 extra-source-files:  benchmarks/aeson/*.hs
                      benchmarks/aeson/*.json
 cabal-version:       >=1.10
-tested-with:         GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1
+tested-with:         GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1 || ==9.0.1
 
 library
   exposed-modules:     Data.ByteString.FastBuilder,
@@ -25,7 +25,7 @@ library
   other-modules:       Data.ByteString.FastBuilder.Internal.Prim
 
   -- other-extensions:
-  build-depends:       base >= 4.8 && < 4.15, bytestring >= 0.10.6.0, ghc-prim
+  build-depends:       base >= 4.8 && < 4.16, bytestring >= 0.10.6.0, ghc-prim
   -- hs-source-dirs:
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/tests/prop.hs
+++ b/tests/prop.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 module Main where
 
 import Control.Concurrent
@@ -94,7 +93,7 @@ buildWithBuilder :: Driver -> BuilderTree -> BS.ByteString
 buildWithBuilder drv = runBuilder drv . mkBuilder
 
 buildWithList :: BuilderTree -> BS.ByteString
-buildWithList = BS.pack . ($[]) . go
+buildWithList = BS.pack . ($ []) . go
   where
     go (Leaf p) = prim p
     go (Mappend a b) = go a . go b


### PR DESCRIPTION
Updated bounds on base to allow 4.15.

Otherwise this was a 1 character change because ghc now parses `$[]` as a TH expression rather than applying an empty list.
