### PR TITLE
enable support for GHC 9.2-9.10

### DIFF
--- a/fast-builder.cabal
+++ b/fast-builder.cabal
@@ -25,7 +25,7 @@ library
   other-modules:       Data.ByteString.FastBuilder.Internal.Prim
 
   -- other-extensions:
-  build-depends:       base >= 4.8 && < 4.16, bytestring >= 0.10.6.0, ghc-prim
+  build-depends:       base >= 4.8 && < 4.17, bytestring >= 0.10.6.0, ghc-prim
   -- hs-source-dirs:
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/fast-builder.cabal
+++ b/fast-builder.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 extra-source-files:  benchmarks/aeson/*.hs
                      benchmarks/aeson/*.json
 cabal-version:       >=1.10
-tested-with:         GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1 || ==9.0.1
+tested-with:         GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1 || ==9.0.1 || ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.2 || ==9.10.1
 
 library
   exposed-modules:     Data.ByteString.FastBuilder,
@@ -25,7 +25,7 @@ library
   other-modules:       Data.ByteString.FastBuilder.Internal.Prim
 
   -- other-extensions:
-  build-depends:       base >= 4.8 && < 4.17, bytestring >= 0.10.6.0, ghc-prim
+  build-depends:       base >= 4.8 && < 4.21, bytestring >= 0.10.6.0, ghc-prim
   -- hs-source-dirs:
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
fast-builder builds as-is with GHC 9.2-9.10, so we relax the upper bounds on base.

I ran the included tests with GHC 9.2, 9.4, 9.6, 9.8, and 9.10.