### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/Data/ByteString/FastBuilder/Internal.hs
+++ b/Data/ByteString/FastBuilder/Internal.hs
@@ -221,12 +221,11 @@ newtype BuildM a = BuildM { runBuildM :: (a -> Builder) -> Builder }
   deriving (Functor)
 
 instance Applicative BuildM where
-  pure = return
+  pure x = BuildM $ \k -> k x
+  {-# INLINE pure #-}
   (<*>) = ap
 
 instance Monad BuildM where
-  return x = BuildM $ \k -> k x
-  {-# INLINE return #-}
   BuildM b >>= f = BuildM $ \k -> b $ \r -> runBuildM (f r) k
   {-# INLINE (>>=) #-}
 


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return